### PR TITLE
Use .env from current working directory

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,9 +1,9 @@
 import os
 import click
-from dotenv import load_dotenv
+from dotenv import load_dotenv, find_dotenv
 from openai import OpenAI
 
-load_dotenv()
+load_dotenv(find_dotenv(usecwd=True))
 
 client = OpenAI()
 


### PR DESCRIPTION
When using `llm-bulk-change` as a command installed via pip, this is necessary to load the `.env` from `cwd` instead of the library folder.